### PR TITLE
Use _doc by default in requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can use this plugin for AWS ES at your own risk.
 - **password** Password for above user (string, default is null)
 - ~~**cluster_name**: name of the cluster (string, default is "elasticsearch")~~ Not used now. May use in the future
 - **index**: index name (string, required)
-- **index_type**: index type (string, required)
+- **index_type**: index type (default is _doc)
 - **id**: document id column (string, default is null)
 - **bulk_actions**: Sets when to flush a new bulk request based on the number of actions currently added. (int, default is 1000)
 - **bulk_size**: Sets when to flush a new bulk request based on the size of actions currently added. (long, default is 5242880)

--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
@@ -87,6 +87,7 @@ public class ElasticsearchOutputPluginDelegate
         void setAlias(Optional<String> aliasName);
 
         @Config("index_type")
+        @ConfigDefault("_doc")
         String getType();
 
         @Config("id")
@@ -235,7 +236,9 @@ public class ElasticsearchOutputPluginDelegate
         log.info(String.format("Connecting to Elasticsearch version:%s", client.getEsVersion(task)));
         log.info("Executing plugin with '{}' mode.", task.getMode());
         client.validateIndexOrAliasName(task.getIndex(), "index");
-        client.validateIndexOrAliasName(task.getType(), "index_type");
+        if (!task.getType().equals("_doc")) {
+            client.validateIndexOrAliasName(task.getType(), "index_type");
+        }
 
         if (task.getMode().equals(Mode.REPLACE)) {
             task.setAlias(Optional.of(task.getIndex()));


### PR DESCRIPTION
In Elasticsearch 7.x, specifying types in requests is deprecated.
https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html